### PR TITLE
Update records.html: 2025 BTC champions and 5km Men's records

### DIFF
--- a/records.html
+++ b/records.html
@@ -132,7 +132,7 @@
           </div>
           <header>
             <h1>Club Records</h1>
-            <p>Last updated April 2025</p>
+            <p>Last updated June 2026</p>
           </header>
           <h3>Bush Turkey Classic</h3>
           <h4>Men's Champion</h4>
@@ -141,6 +141,7 @@
             <li>2022 - Clive Gross</li>
             <li>2023 - Liam McCarthy</li>
             <li>2024 - Taz Savage</li>
+            <li>2025 - Taz Savage</li>
           </ul>
           <h4>Women's Champion</h4>
           <ul>
@@ -148,6 +149,7 @@
             <li>2022 - Charli Weinrauch</li>
             <li>2023 - Claire O'Brien</li>
             <li>2024 - Lisa Dineen</li>
+            <li>2025 - Lisa Dineen</li>
           </ul>
           <h3 id="marathon">Marathon</h3>
           <h4>Men</h4>
@@ -200,9 +202,9 @@
           <h3 id="5km">5km</h3>
           <h4>Men</h4>
           <ol>
-            <li>Clive Gross - 15:23 (2025)</li>
-            <li>Taz Savage - 15:42 (2025)</li>
-            <li>Stephen Butcher - 15:46 (2025)</li>
+            <li>Ewan McFadzen - 15:09 (2026)</li>
+            <li>Stephen Butcher - 15:14 (2026)</li>
+            <li>Clive Gross - 15:23 (2026)</li>
           </ol>
           <h4>Women</h4>
           <ol>


### PR DESCRIPTION
## Summary

Closes #5

- Added 2025 Bush Turkey Classic champions: **Taz Savage** (Men's), **Lisa Dineen** (Women's)
- Replaced 5km Men's top-3 with new 2026 records:
  1. Ewan McFadzen — 15:09 (2026)
  2. Stephen Butcher — 15:14 (2026)
  3. Clive Gross — 15:23 (2026)
- Updated "last updated" date to June 2026

## Test plan
- [ ] Review Champions list shows 2021–2025 for both Men's and Women's
- [ ] Review 5km Men's records show the correct top-3 with 2026 times
- [ ] Verify page renders correctly in browser

https://claude.ai/code/session_01Kws6xedCpnZ76XztypaYxx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kws6xedCpnZ76XztypaYxx)_