### PR TITLE
Fix records.html: 2025 Men's Classic champion and 5km 3rd place time

### DIFF
--- a/records.html
+++ b/records.html
@@ -141,7 +141,7 @@
             <li>2022 - Clive Gross</li>
             <li>2023 - Liam McCarthy</li>
             <li>2024 - Taz Savage</li>
-            <li>2025 - Taz Savage</li>
+            <li>2025 - Oscar Merlin</li>
           </ul>
           <h4>Women's Champion</h4>
           <ul>
@@ -204,7 +204,7 @@
           <ol>
             <li>Ewan McFadzen - 15:09 (2026)</li>
             <li>Stephen Butcher - 15:14 (2026)</li>
-            <li>Clive Gross - 15:23 (2026)</li>
+            <li>Clive Gross - 15:22 (2026)</li>
           </ol>
           <h4>Women</h4>
           <ol>


### PR DESCRIPTION
## Summary

Corrections to records merged in #6:

- **2025 Bush Turkey Classic Men's champion**: Oscar Merlin (was incorrectly listed as Taz Savage)
- **5km Men's 3rd place**: Clive Gross — 15:22 (was incorrectly listed as 15:23)

https://claude.ai/code/session_01Kws6xedCpnZ76XztypaYxx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kws6xedCpnZ76XztypaYxx)_