### PR TITLE
Migrate store links to revolutionise.com.au

### DIFF
--- a/store.html
+++ b/store.html
@@ -56,7 +56,7 @@
 		  content="running gear, athletic apparel, track club merchandise, running accessories, sports store, bush turkey gear"
 		/>
 		<meta name="robots" content="index, follow" />
-		<meta http-equiv="refresh" content="2; url='http://store.bushturkey.club'" />
+		<meta http-equiv="refresh" content="2; url='https://www.revolutionise.com.au/bushturkeytc/shop'" />
 		<link rel="stylesheet" href="assets/css/main.css" />
 		<link rel="stylesheet" href="assets/css/topnav.css" />
 		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
@@ -78,7 +78,7 @@
 				<!-- One -->
 				<section class="wrapper style1 align-center">
 					<div class="inner">
-						<p>Redirecting to <a href="http://store.bushturkey.club">store.bushturkey.club</a></p>
+						<p>Redirecting to <a href="https://www.revolutionise.com.au/bushturkeytc/shop">Bush Turkey TC Shop</a></p>
 						<p class="major">Gobble, gobble!</p>
 					</div>
 				</section>					


### PR DESCRIPTION
## Summary

- Updated `store.html` meta refresh redirect from `http://store.bushturkey.club` to `https://www.revolutionise.com.au/bushturkeytc/shop`
- Updated the visible anchor link text and href to match the new URL

## Test plan

- [ ] Visit `/store.html` and confirm the page auto-redirects to `https://www.revolutionise.com.au/bushturkeytc/shop` after 2 seconds
- [ ] Confirm the displayed link text reads "Bush Turkey TC Shop" and points to the new URL

https://claude.ai/code/session_0174Xxq45cEa6tnV8UnyNhJf

---
_Generated by [Claude Code](https://claude.ai/code/session_0174Xxq45cEa6tnV8UnyNhJf)_